### PR TITLE
Add sunset clause to REQ-6-1 implementation.

### DIFF
--- a/src/buip055fork.cpp
+++ b/src/buip055fork.cpp
@@ -45,6 +45,7 @@
 #include <limits>
 #include <queue>
 
+const int REQ_6_1_SUNSET_HEIGHT = 530000;
 std::vector<unsigned char> invalidOpReturn = {112, 101, 101, 114, 50, 112, 101, 101, 114, 32, 99, 97, 115, 104, 32, 114, 101, 113, 117, 105, 114, 101, 115, 32, 108, 97, 114, 103, 101, 114, 32, 98, 108, 111, 99, 107, 115};
 
 bool UpdateBUIP055Globals(CBlockIndex *activeTip)
@@ -61,12 +62,12 @@ bool UpdateBUIP055Globals(CBlockIndex *activeTip)
     return false;
 }
 
-bool ValidateBUIP055Block(const CBlock &block, CValidationState &state)
+bool ValidateBUIP055Block(const CBlock &block, CValidationState &state, int nHeight)
 {
     // Validate transactions are HF compatible
     for (const CTransaction &tx : block.vtx)
     {
-        if (!ValidateBUIP055Tx(tx))
+        if ((nHeight <= REQ_6_1_SUNSET_HEIGHT) && (!ValidateBUIP055Tx(tx)))
             return state.DoS(100,
                              error("transaction is invalid on BUIP055 chain"), REJECT_INVALID, "bad-txns-wrong-fork");
     }

--- a/src/buip055fork.h
+++ b/src/buip055fork.h
@@ -20,7 +20,7 @@ extern std::vector<unsigned char> invalidOpReturn;
 // Validate that the block's contents adhere to the BUIP055 hard fork requirements.
 // the requirement that the fork block is >= 1MB is not checked because we do not
 // know whether this is the fork block.
-extern bool ValidateBUIP055Block(const CBlock &block, CValidationState &state);
+extern bool ValidateBUIP055Block(const CBlock &block, CValidationState &state, int nHeight);
 
 // Validate that a transaction adheres to the BUIP055 hard fork requirements.
 extern bool ValidateBUIP055Tx(const CTransaction& tx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4082,7 +4082,7 @@ bool ContextualCheckBlock(const CBlock &block, CValidationState &state, CBlockIn
     // BUIP055 check soft-fork items, such as tx targeted to the 1MB chain
     if (pindexPrev && pindexPrev->IsforkActiveOnNextBlock(miningForkTime.value))
     {
-        return ValidateBUIP055Block(block, state);
+        return ValidateBUIP055Block(block, state, nHeight);
     }
 
     return true;


### PR DESCRIPTION
As per UAHF spec (*) section REQ-6-1 once the fork has activated,
transactions containing an OP_RETURN output with a specific magic data
value of

`Bitcoin: A Peer-to-Peer Electronic Cash System`

(46 characters, including the single spaces separating the words, and
without any terminating null character) shall be considered invalid
until block 530,000 inclusive.

This commit just add the sunset clause, i.e. block height lower than
530,001.

(*) https://github.com/Bitcoin-UAHF/spec/blob/master/uahf-technical-spec.md#req-6-1-disallow-special-op_return-marked-transactions-with-sunset-clause