### PR TITLE
XThin cpu benchmarks initial commit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -227,8 +227,8 @@ AC_ARG_ENABLE([zmq],
   [use_zmq=$enableval],
   [use_zmq=yes])
 
-AC_ARG_ENABLE([zmq],
-  [AS_HELP_STRING([--enable-cpu-benchmarks],
+AC_ARG_ENABLE([cpu-benchmark],
+  [AS_HELP_STRING([--enable-cpu-benchmark],
   [enable cpu benchmarks and getbenchmarkinfo rpc call])],
   [enable_cpubenchmark=$enableval],
   [enable_cpubenchmark=no])
@@ -1209,7 +1209,7 @@ if test x$bitcoin_enable_qt != xno; then
     echo "    qt version  = $bitcoin_qt_got_major_vers"
     echo "    with qr     = $use_qr"
 fi
-echo "  with cpu benchmark = $enable_cpubenchmark "
+echo "  with cpu benchmark = $enable_cpubenchmark"
 echo "  with zmq      = $use_zmq"
 echo "  with test     = $use_tests"
 echo "  with bench    = $use_bench"

--- a/configure.ac
+++ b/configure.ac
@@ -227,6 +227,12 @@ AC_ARG_ENABLE([zmq],
   [use_zmq=$enableval],
   [use_zmq=yes])
 
+AC_ARG_ENABLE([zmq],
+  [AS_HELP_STRING([--enable-cpu-benchmarks],
+  [enable cpu benchmarks and getbenchmarkinfo rpc call])],
+  [enable_cpubenchmark=$enableval],
+  [enable_cpubenchmark=no])
+
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 
 # Enable debug
@@ -984,6 +990,16 @@ else
   AC_MSG_RESULT(no)
 fi
 
+dnl enable cpubenchmark
+AC_MSG_CHECKING([if cpubenchmarks should be enabled])
+if test x$enable_cpubenchmark != xno; then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE_UNQUOTED([ENABLE_CPUBENCHMARK],[1],[Define to 1 to enable cpubenchmark functions])
+
+else
+  AC_MSG_RESULT(no)
+fi
+
 dnl enable upnp support
 AC_MSG_CHECKING([whether to build with support for UPnP])
 if test x$have_miniupnpc = xno; then
@@ -1092,6 +1108,7 @@ AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
 AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
 AM_CONDITIONAL([ENABLE_HWCRC32],[test x$enable_hwcrc32 = xyes])
 AM_CONDITIONAL([USE_ASM],[test x$use_asm = xyes])
+AM_CONDITIONAL([ENABLE_CPUBENCHMARK],[test x$enable_cpubenchmark != xno])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])
@@ -1192,6 +1209,7 @@ if test x$bitcoin_enable_qt != xno; then
     echo "    qt version  = $bitcoin_qt_got_major_vers"
     echo "    with qr     = $use_qr"
 fi
+echo "  with cpu benchmark = $enable_cpubenchmark "
 echo "  with zmq      = $use_zmq"
 echo "  with test     = $use_tests"
 echo "  with bench    = $use_bench"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -178,6 +178,10 @@ BITCOIN_CORE_H = \
   zmq/zmqconfig.h\
   zmq/zmqnotificationinterface.h \
   zmq/zmqpublishnotifier.h
+  
+if ENABLE_CPUBENCHMARK
+  BITCOIN_CORE_H += cpu_benchmarks.h
+endif
 
 
 obj/build.h: FORCE
@@ -185,6 +189,7 @@ obj/build.h: FORCE
 	@$(top_srcdir)/share/genbuild.sh $(abs_top_builddir)/src/obj/build.h \
 	  $(abs_top_srcdir)
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
+
 
 # server: shared between bitcoind and bitcoin-qt
 libbitcoin_server_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
@@ -236,6 +241,11 @@ libbitcoin_server_a_SOURCES = \
   validationinterface.cpp \
   versionbits.cpp \
   $(BITCOIN_CORE_H)
+
+if ENABLE_CPUBENCHMARK
+  libbitcoin_server_a_SOURCES += cpu_benchmarks.cpp
+endif
+
 
 if ENABLE_ZMQ
 libbitcoin_zmq_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(ZMQ_CFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ BITCOIN_CORE_H = \
   consensus/consensus.h \
   core_io.h \
   core_memusage.h \
+  cpu_benchmarks.h \
   dosman.h \
   expedited.h \
   fastfilter.h \
@@ -178,10 +179,6 @@ BITCOIN_CORE_H = \
   zmq/zmqconfig.h\
   zmq/zmqnotificationinterface.h \
   zmq/zmqpublishnotifier.h
-  
-if ENABLE_CPUBENCHMARK
-  BITCOIN_CORE_H += cpu_benchmarks.h
-endif
 
 
 obj/build.h: FORCE
@@ -204,6 +201,7 @@ libbitcoin_server_a_SOURCES = \
   buip055fork.cpp \
   chain.cpp \
   checkpoints.cpp \
+  cpu_benchmarks.cpp \
   connmgr.cpp \
   dosman.cpp \
   expedited.cpp \
@@ -241,11 +239,6 @@ libbitcoin_server_a_SOURCES = \
   validationinterface.cpp \
   versionbits.cpp \
   $(BITCOIN_CORE_H)
-
-if ENABLE_CPUBENCHMARK
-  libbitcoin_server_a_SOURCES += cpu_benchmarks.cpp
-endif
-
 
 if ENABLE_ZMQ
 libbitcoin_zmq_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(ZMQ_CFLAGS)

--- a/src/chain.h
+++ b/src/chain.h
@@ -15,6 +15,7 @@
 #include "util.h"
 
 #include <vector>
+#include <atomic>
 
 class CBlockFileInfo
 {

--- a/src/cpu_benchmarks.cpp
+++ b/src/cpu_benchmarks.cpp
@@ -41,10 +41,19 @@ int64_t cpu_xthin_process_reconstruct = 0;
 int64_t cpu_xthin_process_finish = 0;
 
 /** these are for processing the block itself */
+//pthread init + ChainParams()
 int64_t cpu_end_block_process_init = 0;
+
+//ProcessNewBlock()
 int64_t cpu_end_block_process_function_time = 0;
+
+//state.Valid + findMostWorkChain() + LargestBlockSeen
 int64_t cpu_end_block_process_invalid_state_time = 0;
+
+//ClearThinBlockData + thinblock cleanup functions
 int64_t cpu_end_block_process_flightcleanup_time = 0;
+
+//PV cleanup functions
 int64_t cpu_end_block_process_final_time = 0;
 
 

--- a/src/cpu_benchmarks.cpp
+++ b/src/cpu_benchmarks.cpp
@@ -1,0 +1,61 @@
+#include "cpu_benchmarks.h"
+
+/** XTHIN INFO */
+CCriticalSection cs_block_benchmarks;
+
+/** This first set is for the handle message call */
+//CXThinBlock::HandleMessage()
+int64_t cpu_xthin_block_time = 0;
+
+//vRecv >> thinBlock;
+int64_t cpu_xthin_block_deserialize = 0;
+
+//IsThinBlockValid()
+int64_t cpu_xthin_block_isValid_check = 0;
+
+//mapBlockIndex.find(prevHash) + AcceptBlockHeader + !pindex
+int64_t cpu_xthin_block_header_checks = 0;
+
+//UpdateBlockAvailability + ClearThinBlockData + IsExpeditedUpstream + AddThinBlockInFlight + mapThinBlocksInFlight.count ||| AT MOST
+int64_t cpu_xthin_availability_work_expedited = 0;
+
+//IsRecentlyExpeditedAndStore + SendExpeditedBlock
+int64_t cpu_xthin_store_send = 0;
+
+//thinBlock.process
+int64_t cpu_xthin_process = 0;
+
+// bunch of misc constructors and setters and stuff
+int64_t cpu_xthin_process_start = 0;
+
+//mapOrphanTransactions iterate through + set collision
+int64_t cpu_xthin_process_orphans = 0;
+
+//mempool.queryHashes + iterate through all hashes + pfrom->mapMissingTx iteration + foreach on vTxHashes + ComputeMerkleRoot + ReconstructBlock ||| AT MOST
+int64_t cpu_xthin_process_mempool = 0;
+
+//ReconstructBlock
+int64_t cpu_xthin_process_reconstruct = 0;
+
+//finish up function, lauch process block thread and do remaining collision checks
+int64_t cpu_xthin_process_finish = 0;
+
+/** these are for processing the block itself */
+int64_t cpu_end_block_process_init = 0;
+int64_t cpu_end_block_process_function_time = 0;
+int64_t cpu_end_block_process_invalid_state_time = 0;
+int64_t cpu_end_block_process_flightcleanup_time = 0;
+int64_t cpu_end_block_process_final_time = 0;
+
+
+/** XTHIN TX INFO */
+int64_t cpu_xthin_tx_time = 0;
+
+
+
+
+
+
+/** MEMPOOL INFO */
+int64_t cpu_mempool_time = 0;
+

--- a/src/cpu_benchmarks.cpp
+++ b/src/cpu_benchmarks.cpp
@@ -1,4 +1,6 @@
+#if defined(ENABLE_CPUBENCHMARK)
 #include "cpu_benchmarks.h"
+#endif
 
 /** XTHIN INFO */
 CCriticalSection cs_block_benchmarks;

--- a/src/cpu_benchmarks.cpp
+++ b/src/cpu_benchmarks.cpp
@@ -1,6 +1,4 @@
-#if defined(ENABLE_CPUBENCHMARK)
 #include "cpu_benchmarks.h"
-#endif
 
 /** XTHIN INFO */
 CCriticalSection cs_block_benchmarks;

--- a/src/cpu_benchmarks.h
+++ b/src/cpu_benchmarks.h
@@ -1,0 +1,40 @@
+#ifndef CPU_BENCHMARKS_H
+#define CPU_BENCHMARKS_H
+
+#include <stdint.h>
+#include "sync.h"
+
+extern CCriticalSection cs_block_benchmarks;
+
+// additional info about all timers in cpu_benchmarks.cpp
+
+/** XTHIN INFO */
+extern int64_t cpu_xthin_block_time;
+extern int64_t cpu_xthin_block_deserialize;
+extern int64_t cpu_xthin_block_isValid_check;
+extern int64_t cpu_xthin_block_header_checks;
+extern int64_t cpu_xthin_availability_work_expedited;
+extern int64_t cpu_xthin_store_send;
+extern int64_t cpu_xthin_process;
+extern int64_t cpu_xthin_process_start;
+extern int64_t cpu_xthin_process_orphans;
+extern int64_t cpu_xthin_process_mempool;
+extern int64_t cpu_xthin_process_reconstruct;
+extern int64_t cpu_xthin_process_finish;
+
+extern int64_t cpu_end_block_process_init;
+extern int64_t cpu_end_block_process_function_time;
+extern int64_t cpu_end_block_process_invalid_state_time;
+extern int64_t cpu_end_block_process_flightcleanup_time;
+extern int64_t cpu_end_block_process_final_time;
+
+/** XTHIN TX INFO */
+extern int64_t cpu_xthin_tx_time;
+
+
+
+/** MEMPOOL INFO */
+extern int64_t cpu_mempool_time;
+
+
+#endif // CPU_BENCHMARKS_H

--- a/src/cpu_benchmarks.h
+++ b/src/cpu_benchmarks.h
@@ -2,9 +2,44 @@
 #define CPU_BENCHMARKS_H
 
 #include <stdint.h>
-#include "sync.h"
+#include "stat.h"
 
 extern CCriticalSection cs_block_benchmarks;
+
+
+
+/* used to store a Stat on disk for later reading, contains additional data on top of a Stat */
+class CBenchmarkStat
+{
+public:
+    std::string benchmarkName;
+    CStatMap mapStats;
+    int nStartHeight;
+    int nEndHeight;
+    int64_t nStartTime;
+    int64_t nEndTime;
+    int nBlockCount;
+    int64_t nRunTime;
+
+public:
+    CBenchmarkStat()
+    {
+        setNull();
+    }
+
+    void setNull()
+    {
+        benchmarkName.clear();
+        mapStats.clear();
+        nStartHeight = 0;
+        nEndHeight = 0;
+        nStartTime = 0;
+        nEndTime = 0;
+        nBlockCount = 0;
+        nRunTime = 0;
+    }
+}
+
 
 // additional info about all timers in cpu_benchmarks.cpp
 

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -74,7 +74,9 @@ public:
 
     void reset()
     {
-        bzero(&vData[0],FILTER_BYTES);
+        /// Changed this to memset from bzero. bzero is deprecated on most OS
+        /// and reduces portability since it is not a standard C function - Griffith
+        memset(&vData[0],0,FILTER_BYTES);
     }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6326,7 +6326,15 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsThinBlocksEnabled())
     {
+#if defined(BENCHMARK_CPU)
+      int64_t start = GetTimeBenchmark();
+      bool handleMessage = CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
+      int64_t end = GetTimeBenchmark();
+      cpu_xthin_block_time += (end - start);
+      return handleMessage;
+#else
         return CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
+#endif
     }
 
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -17,7 +17,9 @@
 
 #include <boost/thread/thread.hpp>
 
+#if defined(ENABLE_CPUBENCHMARK)
 #include "cpu_benchmarks.h"
+#endif
 
 using namespace std;
 
@@ -549,7 +551,7 @@ void HandleBlockMessageThread(CNode *pfrom,
     uint64_t nSizeBlock)
 {
 
-#if defined(BENCHMARK_CPU)
+#if defined(ENABLE_CPUBENCHMARK)
     int64_t start_block_processing = GetTimeBenchmark();
 #endif
 
@@ -576,7 +578,7 @@ void HandleBlockMessageThread(CNode *pfrom,
     bool forceProcessing = pfrom->fWhitelisted && !IsInitialBlockDownload();
     const CChainParams &chainparams = Params();
 
-#if defined(BENCHMARK_CPU)
+#if defined(ENABLE_CPUBENCHMARK)
     int64_t end_block_process_start = GetTimeBenchmark();
     int64_t end_process_block_init = end_block_process_start - start_block_processing;
 #endif
@@ -591,7 +593,7 @@ void HandleBlockMessageThread(CNode *pfrom,
         ProcessNewBlock(state, chainparams, pfrom, block.get(), forceProcessing, NULL, false);
     }
 
-#if defined(BENCHMARK_CPU)
+#if defined(ENABLE_CPUBENCHMARK)
     int64_t end_block_process_finish = GetTimeBenchmark();
     int64_t end_block_process_finish_time = end_block_process_finish - end_block_process_start;
 #endif
@@ -638,7 +640,7 @@ void HandleBlockMessageThread(CNode *pfrom,
                 (double)(GetTimeMicros() - startTime) / 1000000.0, pfrom->GetLogName());
     }
 
-#if defined(BENCHMARK_CPU)
+#if defined(ENABLE_CPUBENCHMARK)
     int64_t end_block_process_invalid_state = GetTimeBenchmark();
     int64_t end_block_process_invalid_state_time = end_block_process_invalid_state - end_block_process_finish;
 #endif
@@ -680,7 +682,7 @@ void HandleBlockMessageThread(CNode *pfrom,
         }
     }
 
-#if defined(BENCHMARK_CPU)
+#if defined(ENABLE_CPUBENCHMARK)
     int64_t end_block_process_flightcleanup = GetTimeBenchmark();
     int64_t end_block_process_flightcleanup_time = end_block_process_flightcleanup - end_block_process_invalid_state;
 #endif
@@ -709,7 +711,7 @@ void HandleBlockMessageThread(CNode *pfrom,
     if (IsChainNearlySyncd())
         FlushStateToDisk(state, FLUSH_STATE_ALWAYS);
 
-#if defined(BENCHMARK_CPU)
+#if defined(ENABLE_CPUBENCHMARK)
     int64_t end_block_process_final = GetTimeBenchmark();
     int64_t end_block_process_final_time = end_block_process_final - end_block_process_flightcleanup;
     {

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -716,11 +716,11 @@ void HandleBlockMessageThread(CNode *pfrom,
     int64_t end_block_process_final_time = end_block_process_final - end_block_process_flightcleanup;
     {
         LOCK(cs_block_benchmarks);
-        cpu_end_block_process_init = end_process_block_init;
-        cpu_end_block_process_function_time = end_block_process_finish_time;
-        cpu_end_block_process_invalid_state_time = end_block_process_invalid_state_time;
-        cpu_end_block_process_flightcleanup_time = end_block_process_flightcleanup_time;
-        cpu_end_block_process_final_time = end_block_process_final_time;
+        cpu_end_block_process_init += end_process_block_init;
+        cpu_end_block_process_function_time += end_block_process_finish_time;
+        cpu_end_block_process_invalid_state_time += end_block_process_invalid_state_time;
+        cpu_end_block_process_flightcleanup_time += end_block_process_flightcleanup_time;
+        cpu_end_block_process_final_time += end_block_process_final_time;
     }
 #endif
 }

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -17,6 +17,8 @@
 
 #include <boost/thread/thread.hpp>
 
+#include "cpu_benchmarks.h"
+
 using namespace std;
 
 static const unsigned int nScriptCheckQueues = 4;
@@ -546,6 +548,11 @@ void HandleBlockMessageThread(CNode *pfrom,
     const CInv inv,
     uint64_t nSizeBlock)
 {
+
+#if defined(BENCHMARK_CPU)
+    int64_t start_block_processing = GetTimeBenchmark();
+#endif
+
     int64_t startTime = GetTimeMicros();
     CValidationState state;
 
@@ -568,6 +575,12 @@ void HandleBlockMessageThread(CNode *pfrom,
     // conditions in AcceptBlock().
     bool forceProcessing = pfrom->fWhitelisted && !IsInitialBlockDownload();
     const CChainParams &chainparams = Params();
+
+#if defined(BENCHMARK_CPU)
+    int64_t end_block_process_start = GetTimeBenchmark();
+    int64_t end_process_block_init = end_block_process_start - start_block_processing;
+#endif
+
     if (PV->Enabled())
     {
         ProcessNewBlock(state, chainparams, pfrom, block.get(), forceProcessing, NULL, true);
@@ -577,6 +590,11 @@ void HandleBlockMessageThread(CNode *pfrom,
         LOCK(cs_main); // locking cs_main here prevents any other thread from beginning starting a block validation.
         ProcessNewBlock(state, chainparams, pfrom, block.get(), forceProcessing, NULL, false);
     }
+
+#if defined(BENCHMARK_CPU)
+    int64_t end_block_process_finish = GetTimeBenchmark();
+    int64_t end_block_process_finish_time = end_block_process_finish - end_block_process_start;
+#endif
 
     int nDoS;
     if (state.IsInvalid(nDoS))
@@ -620,6 +638,11 @@ void HandleBlockMessageThread(CNode *pfrom,
                 (double)(GetTimeMicros() - startTime) / 1000000.0, pfrom->GetLogName());
     }
 
+#if defined(BENCHMARK_CPU)
+    int64_t end_block_process_invalid_state = GetTimeBenchmark();
+    int64_t end_block_process_invalid_state_time = end_block_process_invalid_state - end_block_process_finish;
+#endif
+
     // When we request a thinblock we may get back a regular block if it is smaller than a thinblock
     // Therefore we have to remove the thinblock in flight if it exists and we also need to check that
     // the block didn't arrive from some other peer.  This code ALSO cleans up the thin block that
@@ -657,6 +680,11 @@ void HandleBlockMessageThread(CNode *pfrom,
         }
     }
 
+#if defined(BENCHMARK_CPU)
+    int64_t end_block_process_flightcleanup = GetTimeBenchmark();
+    int64_t end_block_process_flightcleanup_time = end_block_process_flightcleanup - end_block_process_invalid_state;
+#endif
+
     // Erase any txns from the orphan cache that are no longer needed
     PV->ClearOrphanCache(*block);
 
@@ -680,6 +708,19 @@ void HandleBlockMessageThread(CNode *pfrom,
     // process the block advance the tip.
     if (IsChainNearlySyncd())
         FlushStateToDisk(state, FLUSH_STATE_ALWAYS);
+
+#if defined(BENCHMARK_CPU)
+    int64_t end_block_process_final = GetTimeBenchmark();
+    int64_t end_block_process_final_time = end_block_process_final - end_block_process_flightcleanup;
+    {
+        LOCK(cs_block_benchmarks);
+        cpu_end_block_process_init = end_process_block_init;
+        cpu_end_block_process_function_time = end_block_process_finish_time;
+        cpu_end_block_process_invalid_state_time = end_block_process_invalid_state_time;
+        cpu_end_block_process_flightcleanup_time = end_block_process_flightcleanup_time;
+        cpu_end_block_process_final_time = end_block_process_final_time;
+    }
+#endif
 }
 
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -19,7 +19,9 @@
 #include "wallet/walletdb.h"
 #endif
 
+#if defined(ENABLE_CPUBENCHMARK)
 #include "cpu_benchmarks.h"
+#endif
 
 #include <stdint.h>
 
@@ -157,7 +159,7 @@ UniValue getbenchmarkinfo(const UniValue& params, bool fHelp)
 
     UniValue obj(UniValue::VOBJ);
 
-#ifdef CPU_BENCHMARK
+#ifdef ENABLE_CPUBENCHMARK
     {
         LOCK(cs_block_benchmarks);
         obj.push_back(Pair("Time spent in", "Microseconds"));
@@ -181,7 +183,7 @@ UniValue getbenchmarkinfo(const UniValue& params, bool fHelp)
         obj.push_back(Pair("xthin blk msg thread close",cpu_end_block_process_final_time));
     }
 #else
-        obj.push_back(Pair("Error", "Benchmarks not active, restart with CPU_BENCHMARKS to use this rpc call"));
+        obj.push_back(Pair("Error", "Benchmarks not active, restart with ENABLE_CPUBENCHMARK to use this rpc call"));
 #endif
 
 
@@ -483,7 +485,7 @@ static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
     { "control",            "getinfo",                &getinfo,                true  }, /* uses wallet if enabled */
-    { "control",            "getbenchmarkinfo",       &getbenchmarkinfo,       true  }, /* uses CPU_BENCHMARK if enabled */
+    { "control",            "getbenchmarkinfo",       &getbenchmarkinfo,       true  }, /* uses ENABLE_CPUBENCHMARK if enabled */
     { "util",               "validateaddress",        &validateaddress,        true  }, /* uses wallet if enabled */
     { "util",               "createmultisig",         &createmultisig,         true  },
     { "util",               "verifymessage",          &verifymessage,          true  },

--- a/src/stat.h
+++ b/src/stat.h
@@ -95,6 +95,14 @@ public:
         statistics[CStatKey(name)] = this;
     }
 
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(value);
+        READWRITE(name);
+    }
+
     void init(const char *namep)
     {
         LOCK(cs_statMap);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -23,6 +23,8 @@
 #include "util.h"
 #include "utiltime.h"
 
+#include "cpu_benchmarks.h"
+
 using namespace std;
 
 static bool ReconstructBlock(CNode *pfrom, const bool fXVal, int &missingCount, int &unnecessaryCount);
@@ -546,15 +548,40 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
         return error("%s message received from a non XTHIN node, peer=%s", strCommand, pfrom->GetLogName());
     }
 
+#if defined(BENCHMARK_CPU)
+    int64_t start_deserialize = GetTimeBenchmark();
+#endif
+
     int nSizeThinBlock = vRecv.size();
     CInv inv(MSG_BLOCK, uint256());
 
     CXThinBlock thinBlock;
     vRecv >> thinBlock;
 
+#if defined(BENCHMARK_CPU)
+    int64_t end_deserialize = GetTimeBenchmark();
+    cpu_xthin_block_deserialize += (end_deserialize - start_deserialize);
+#endif
     {
         LOCK(cs_main);
 
+#if defined(BENCHMARK_CPU)
+      int64_t start_isValid = GetTimeBenchmark();
+
+      // Message consistency checking (FIXME: some redundancy here with AcceptBlockHeader)
+      if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
+      {
+          dosMan.Misbehaving(pfrom, 100);
+          LogPrintf("Received an invalid %s from peer %s\n", strCommand, pfrom->GetLogName());
+
+          thindata.ClearThinBlockData(pfrom, thinBlock.header.GetHash());
+          int64_t end_isValid_failed = GetTimeBenchmark();
+          cpu_xthin_block_isValid_check += (end_isValid_failed - start_isValid);
+          return false;
+      }
+      int64_t end_isvalid = GetTimeBenchmark();
+      cpu_xthin_block_isValid_check += (end_isvalid - start_isValid);
+#else
         // Message consistency checking (FIXME: some redundancy here with AcceptBlockHeader)
         if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
         {
@@ -564,7 +591,12 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
             thindata.ClearThinBlockData(pfrom, thinBlock.header.GetHash());
             return false;
         }
+#endif
 
+
+#if defined(BENCHMARK_CPU)
+    int64_t start_header_checks = GetTimeBenchmark();
+#endif
         // Is there a previous block or header to connect with?
         {
             uint256 prevHash = thinBlock.header.hashPrevBlock;
@@ -599,7 +631,12 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
             thindata.ClearThinBlockData(pfrom, thinBlock.header.GetHash());
             return true;
         }
-
+#if defined(BENCHMARK_CPU)
+    int64_t end_header_checks = GetTimeBenchmark();
+    cpu_xthin_block_header_checks += (end_header_checks - start_header_checks);
+///
+    int64_t start_availability = GetTimeBenchmark();
+#endif
         inv.hash = pIndex->GetBlockHash();
         UpdateBlockAvailability(pfrom->GetId(), inv.hash);
 
@@ -613,8 +650,12 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
             LogPrint("thin", "Received xthinblock but returning because we already have block data %s from peer %s hop"
                              " %d size %d bytes\n",
                 inv.hash.ToString(), pfrom->GetLogName(), nHops, nSizeThinBlock);
+#if defined(BENCHMARK_CPU)
+    int64_t end_availability_haveData = GetTimeBenchmark();
+    cpu_xthin_availability_work_expedited += (end_availability_haveData - start_availability);
+#endif
             return true;
-        }
+        }    
 
         // Request full block if it isn't extending the best chain
         if (pIndex->nChainWork <= chainActive.Tip()->nChainWork)
@@ -627,6 +668,10 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
 
             LogPrintf("%s %s from peer %s received but does not extend longest chain; requesting full block\n",
                 strCommand, inv.hash.ToString(), pfrom->GetLogName());
+#if defined(BENCHMARK_CPU)
+    int64_t end_availability_lessWork = GetTimeBenchmark();
+    cpu_xthin_availability_work_expedited += (end_availability_lessWork - start_availability);
+#endif
             return true;
         }
 
@@ -650,23 +695,50 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
             if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
             {
                 dosMan.Misbehaving(pfrom, 10);
+#if defined(BENCHMARK_CPU)
+    int64_t end_availability_end3 = GetTimeBenchmark();
+    cpu_xthin_availability_work_expedited += (end_availability_end3 - start_availability);
+#endif
                 return error(
                     "%s %s from peer %s but was unrequested\n", strCommand, inv.hash.ToString(), pfrom->GetLogName());
             }
         }
+#if defined(BENCHMARK_CPU)
+    int64_t end_availability = GetTimeBenchmark();
+    cpu_xthin_availability_work_expedited += (end_availability - start_availability);
+#endif
     }
 
+
+#if defined(BENCHMARK_CPU)
+    int64_t start_store_send = GetTimeBenchmark();
+#endif
     // Send expedited block without checking merkle root.
     if (!IsRecentlyExpeditedAndStore(inv.hash))
         SendExpeditedBlock(thinBlock, nHops, pfrom);
 
+#if defined(BENCHMARK_CPU)
+    int64_t end_store_send = GetTimeBenchmark();
+    cpu_xthin_store_send += (end_store_send - start_store_send);
+///
+    int64_t start_process = GetTimeBenchmark();
+    bool xthinProcess = thinBlock.process(pfrom, nSizeThinBlock, strCommand);
+    int64_t end_process = GetTimeBenchmark();
+    cpu_xthin_process += (end_process - start_process);
+    return xthinProcess;
+#else
     return thinBlock.process(pfrom, nSizeThinBlock, strCommand);
+#endif
 }
 
 bool CXThinBlock::process(CNode *pfrom,
     int nSizeThinBlock,
     string strCommand) // TODO: request from the "best" txn source not necessarily from the block source
 {
+
+#if defined(BENCHMARK_CPU)
+    int64_t start_process_initial = GetTimeBenchmark();
+#endif
     // In PV we must prevent two thinblocks from simulaneously processing from that were recieved from the
     // same peer. This would only happen as in the example of an expedited block coming in
     // after an xthin request, because we would never explicitly request two xthins from the same peer.
@@ -708,7 +780,18 @@ bool CXThinBlock::process(CNode *pfrom,
     set<uint64_t> setHashesToRequest;
 
     bool fMerkleRootCorrect = true;
+
+#if defined(BENCHMARK_CPU)
+    int64_t end_process_initial = GetTimeBenchmark();
+    cpu_xthin_process_start += (end_process_initial - start_process_initial);
+#endif
+
     {
+
+#if defined(BENCHMARK_CPU)
+    int64_t start_process_orphans = GetTimeBenchmark();
+#endif
+
         // Do the orphans first before taking the mempool.cs lock, so that we maintain correct locking order.
         READLOCK(cs_orphancache);
         for (map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end();
@@ -723,6 +806,12 @@ bool CXThinBlock::process(CNode *pfrom,
             }
         }
 
+#if defined(BENCHMARK_CPU)
+    int64_t end_process_orphans = GetTimeBenchmark();
+    cpu_xthin_process_orphans += (end_process_orphans - start_process_orphans);
+///
+    int64_t start_process_mempool = GetTimeBenchmark();
+#endif
         // We don't have to keep the lock on mempool.cs here to do mempool.queryHashes
         // but we take the lock anyway so we don't have to re-lock again later.
         READLOCK(mempool.cs);
@@ -802,13 +891,34 @@ bool CXThinBlock::process(CNode *pfrom,
                 }
                 else
                 {
+#if defined(BENCHMARK_CPU)
+    int64_t start_process_reconstruct = GetTimeBenchmark();
+                    if (!ReconstructBlock(pfrom, fXVal, missingCount, unnecessaryCount))
+                    {
+                        int64_t end_process_reconstruct_fail = GetTimeBenchmark();
+                        cpu_xthin_process_reconstruct += (end_process_reconstruct_fail - start_process_reconstruct);
+                        return false;
+                    }
+    int64_t end_process_reconstruct = GetTimeBenchmark();
+    cpu_xthin_process_reconstruct += (end_process_reconstruct - start_process_reconstruct);
+#else
                     if (!ReconstructBlock(pfrom, fXVal, missingCount, unnecessaryCount))
                         return false;
+#endif
                 }
             }
         }
+#if defined(BENCHMARK_CPU)
+    int64_t end_process_mempool = GetTimeBenchmark();
+    cpu_xthin_process_mempool += (end_process_mempool - start_process_mempool);
+#endif
+
     } // End locking cs_orphancache, mempool.cs and cs_xval
     LogPrint("thin", "Total in memory thinblockbytes size is %ld bytes\n", thindata.GetThinBlockBytes());
+
+#if defined(BENCHMARK_CPU)
+    int64_t start_process_finish = GetTimeBenchmark();
+#endif
 
     // These must be checked outside of the mempool.cs lock or deadlock may occur.
     // A merkle root mismatch here does not cause a ban because and expedited node will forward an xthin
@@ -822,6 +932,10 @@ bool CXThinBlock::process(CNode *pfrom,
         vGetData.push_back(CInv(MSG_THINBLOCK, header.GetHash()));
         pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
 
+#if defined(BENCHMARK_CPU)
+    int64_t end_process_finish_collision_or_badroot = GetTimeBenchmark();
+    cpu_xthin_process_finish += (end_process_finish_collision_or_badroot - start_process_finish);
+#endif
         if (!fMerkleRootCorrect)
             return error(
                 "mismatched merkle root on xthinblock: rerequesting a thinblock, peer=%s", pfrom->GetLogName());
@@ -849,6 +963,10 @@ bool CXThinBlock::process(CNode *pfrom,
 
         LogPrint("thin", "Sending re-req for %d missing transaction(s), peer=%s", pfrom->thinBlockWaitingForTxns,
             pfrom->GetLogName());
+#if defined(BENCHMARK_CPU)
+    int64_t end_process_finish_missing = GetTimeBenchmark();
+    cpu_xthin_process_finish += (end_process_finish_missing - start_process_finish);
+#endif
         return true;
     }
 
@@ -862,6 +980,10 @@ bool CXThinBlock::process(CNode *pfrom,
         std::vector<CInv> vGetData;
         vGetData.push_back(CInv(MSG_BLOCK, header.GetHash()));
         pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
+#if defined(BENCHMARK_CPU)
+    int64_t end_process_finish_missingtx = GetTimeBenchmark();
+    cpu_xthin_process_finish += (end_process_finish_missingtx - start_process_finish);
+#endif
         return error("Still missing transactions for xthinblock: re-requesting a full block");
     }
 
@@ -880,6 +1002,11 @@ bool CXThinBlock::process(CNode *pfrom,
     // Process the full block
     PV->HandleBlockMessage(
         pfrom, strCommand, std::shared_ptr<CBlock>(std::shared_ptr<CBlock>{}, &pfrom->thinBlock), GetInv(), blockSize);
+
+#if defined(BENCHMARK_CPU)
+    int64_t end_process_finish = GetTimeBenchmark();
+    cpu_xthin_process_finish += (end_process_finish - start_process_finish);
+#endif
 
     return true;
 }

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -101,7 +101,7 @@ class CTxInputData
 {
 public:
     CTransaction tx;
-    uint nodeId; // hold the id so I don't keep a ref to the node
+    uint64_t nodeId; // hold the id so I don't keep a ref to the node
     bool whitelisted;
     std::string nodeName;
 };

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -46,6 +46,15 @@ int64_t GetTimeMicros()
     return now;
 }
 
+int64_t GetTimeBenchmark()
+{
+    int64_t now = (boost::posix_time::microsec_clock::universal_time() -
+                      boost::posix_time::ptime(boost::gregorian::date(1970, 1, 1)))
+                      .total_microseconds();
+    assert(now > 0);
+    return now;
+}
+
 uint64_t GetStopwatch()
 {
     struct timespec t;

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -13,10 +13,11 @@
 int64_t GetTime();
 int64_t GetTimeMillis();
 int64_t GetTimeMicros();
+int64_t GetTimeBenchmark();
 int64_t GetLogTimeMicros();
 void SetMockTime(int64_t nMockTimeIn);
 void MilliSleep(int64_t n);
-uint64_t GetStopwatch(); // Returns a monotonically increasing time for interval measurement (in nSec)
+uint64_t GetStopwatch(); // Returns a monotonically increasing time for interval measurement (in nanoseconds)
 std::string DateTimeStrFormat(const char *pszFormat, int64_t nTime);
 
 #endif // BITCOIN_UTILTIME_H


### PR DESCRIPTION
- added benchmarks for xthin blocks and xthin block message handling. 
- added configure flag --enable-cpu-benchmark to turn on the benchmark sections of the code. this also turns on the RPC call in getbenchmarkinfo

Note: the benchmark coded i added could probably be cleaned up a bit, and expanded. 

- changed bzero to memset in fastfilter.h, see comment above change for details
- added <atomic> include to chain.h for portability, changed uint to uint64_t in unlimited.cpp for portability (use stdint.h types for portability across all platforms)

[please squash this when merging if everything is ok, 6 or so commits at the end are a learning curve on the Makefile.am and configure.ac system since i needed an easy way to jump across systems for testing]
