### PR TITLE
Fix MinGW compile errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2121,7 +2121,7 @@ bool ConnectBlock(const CBlock &block,
                 // Only check inputs when the tx hash in not in the setPreVerifiedTxHash as would only
                 // happen if this were a regular block or when a tx is found within the returning XThinblock.
                 uint256 hash = tx.GetHash();
-                if (fCheckInputs == CheckTxInputsOption::TRUE)
+                if (fCheckInputs == CheckTxInputsOption::YES)
                 {
                     {
                         LOCK(cs_xval);

--- a/src/main.h
+++ b/src/main.h
@@ -500,8 +500,8 @@ bool DisconnectBlock(const CBlock &block,
 
 enum class CheckTxInputsOption
 {
-    FALSE = 0,
-    TRUE = 1,
+    NO = 0,
+    YES = 1,
 };
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
@@ -511,7 +511,7 @@ bool ConnectBlock(const CBlock &block,
     CCoinsViewCache &coins,
     bool fJustCheck = false,
     bool fParallel = false,
-    CheckTxInputsOption fCheckInputs = CheckTxInputsOption::TRUE);
+    CheckTxInputsOption fCheckInputs = CheckTxInputsOption::YES);
 
 /** Context-independent validity checks */
 bool CheckBlockHeader(const CBlockHeader &block, CValidationState &state, bool fCheckPOW = true);
@@ -534,7 +534,7 @@ bool TestBlockValidity(CValidationState &state,
     CBlockIndex *pindexPrev,
     bool fCheckPOW = true,
     bool fCheckMerkleRoot = true,
-    CheckTxInputsOption fCheckInputs = CheckTxInputsOption::TRUE);
+    CheckTxInputsOption fCheckInputs = CheckTxInputsOption::YES);
 
 // BU needed in unlimited.cpp
 bool CheckIndexAgainstCheckpoint(const CBlockIndex *pindexPrev,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -242,7 +242,7 @@ CBlockTemplate *BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn, bo
             {
                 // WRT TxInputs: transactions would not ever enter the mempool if their inputs were invalid
                 if (!TestBlockValidity(
-                        state, chainparams, *pblock, pindexPrev, false, false, CheckTxInputsOption::FALSE))
+                        state, chainparams, *pblock, pindexPrev, false, false, CheckTxInputsOption::NO))
                 {
                     throw std::runtime_error(
                         strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -458,7 +458,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             if (block.hashPrevBlock != pindexPrev->GetBlockHash())
                 return "inconclusive-not-best-prevblk";
             CValidationState state;
-            TestBlockValidity(state, Params(), block, pindexPrev, false, true, CheckTxInputsOption::FALSE);
+            TestBlockValidity(state, Params(), block, pindexPrev, false, true, CheckTxInputsOption::NO);
             return BIP22ValidationResult(state);
         }
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1651,7 +1651,7 @@ UniValue validateblocktemplate(const UniValue &params, bool fHelp)
         else
         {
             // No need to test transaction inputs because the tx would not be in the mempool if it was invalid
-            if (!TestBlockValidity(state, chainparams, block, pindexPrev, false, true, CheckTxInputsOption::TRUE))
+            if (!TestBlockValidity(state, chainparams, block, pindexPrev, false, true, CheckTxInputsOption::YES))
             {
                 throw runtime_error(std::string("invalid block: ") + state.GetRejectReason());
             }

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -142,7 +142,7 @@ bool validate(const TxoGroup& grp,const CAmount targetValue)
 // Select coins.
 TxoGroup CoinSelection(/*const*/ SpendableTxos& available, const CAmount targetValue,const CAmount &dust,CFeeRate feeRate, unsigned int changeLen)
 {
-  uint utxosInWallet = available.size();
+  uint64_t utxosInWallet = available.size();
   SpendableTxos::iterator aEnd = available.end();
   TxoGroupMap solutions;
   TxoGroupMap candidates;
@@ -229,7 +229,7 @@ TxoGroup CoinSelection(/*const*/ SpendableTxos& available, const CAmount targetV
 	}
 #endif
 
-      uint nSolutions = solutions.size();
+      uint64_t nSolutions = solutions.size();
       if ((GetTimeMillis() - startTime > maxCoinSelSearchTime.value)&&(nSolutions >= 1)) // Have we looked for a long time
         {
           LogPrint("wallet","CoinSelection searched for the alloted time and found %d solutions\n",nSolutions);


### PR DESCRIPTION
refactor CheckTxInputsOption from FALSE TRUE to NO YES due to FALSE and TRUE being defined within MinGW compiler includes (minwindef.h) and change uint to its stdint.h equivalent for portability. 