### PR TITLE
Update windows rebuild-bitcoin.bat script to account for

### DIFF
--- a/build-aux/mingw/rebuild-bitcoin.bat
+++ b/build-aux/mingw/rebuild-bitcoin.bat
@@ -150,6 +150,7 @@ cd "%BITCOIN_GIT_ROOT%\src"
 copy bitcoin-tx.exe "%BUILD_OUTPUT%\bitcoin-tx.exe"
 copy bitcoin-cli.exe "%BUILD_OUTPUT%\bitcoin-cli.exe"
 copy bitcoind.exe "%BUILD_OUTPUT%\bitcoind.exe"
+copy bitcoin-miner.exe "%BUILD_OUTPUT%\bitcoin-miner.exe"
 
 REM cd to src\qt to copy bitcoin-qt.exe
 cd qt


### PR DESCRIPTION
bitcoin-miner.exe

When finished building all binaries we need to copy the
bitcoin-miner.exe to the correct build output folder along with all the
other binaries.